### PR TITLE
add in a generic lambda for sending batch status reports

### DIFF
--- a/applications/avr/batch.tf
+++ b/applications/avr/batch.tf
@@ -1,0 +1,81 @@
+resource "aws_cloudwatch_event_rule" "batch_status_finished" {
+  name                  = "${local.namespace}-batch-status-finished"
+  description           = "Check on finished batch jobs"
+  schedule_expression   = "rate(15 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "batch_status_finished" {
+  rule  = "${aws_cloudwatch_event_rule.batch_status_finished.name}"
+  arn   = "${module.batch_status_finished.function_arn}"
+}
+
+resource "aws_lambda_permission" "batch_status_finished" {
+  statement_id    = "AllowExecutionFromCloudWatch"
+  action          = "lambda:InvokeFunction"
+  function_name   = "${module.batch_status_finished.function_name}"
+  principal       = "events.amazonaws.com"
+}
+
+module "batch_status_finished" {
+  source = "git://github.com/claranet/terraform-aws-lambda"
+
+  function_name = "${local.namespace}-batch-finished"
+  description   = "Run batch status checks"
+  handler       = "index.handler"
+  runtime       = "nodejs8.10"
+  timeout       = 300
+
+  source_path   = "${path.module}/lambdas/batch_status"
+
+  attach_policy = true
+  policy        = "${data.aws_iam_policy_document.this_batch_ingest_access.json}"
+
+  environment {
+    variables {
+      JobClassName = "IngestBatchStatusEmailJobs::IngestFinished"
+      QueueUrl     = "${aws_sqs_queue.this_batch_queue.id}"
+      Secret       = "${random_id.secret_key_base.hex}"
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "batch_status_stalled" {
+  name                  = "${local.namespace}-batch-status-stalled"
+  description           = "Check on stalled batch jobs"
+  schedule_expression   = "rate(1 day)"
+}
+
+resource "aws_cloudwatch_event_target" "batch_status_stalled" {
+  rule  = "${aws_cloudwatch_event_rule.batch_status_stalled.name}"
+  arn   = "${module.batch_status_stalled.function_arn}"
+}
+
+resource "aws_lambda_permission" "batch_status_stalled" {
+  statement_id    = "AllowExecutionFromCloudWatch"
+  action          = "lambda:InvokeFunction"
+  function_name   = "${module.batch_status_stalled.function_name}"
+  principal       = "events.amazonaws.com"
+}
+
+module "batch_status_stalled" {
+  source = "git://github.com/claranet/terraform-aws-lambda"
+
+  function_name = "${local.namespace}-batch-stalled"
+  description   = "Run batch stalled checks"
+  handler       = "index.handler"
+  runtime       = "nodejs8.10"
+  timeout       = 300
+
+  source_path   = "${path.module}/lambdas/batch_status"
+
+  attach_policy = true
+  policy        = "${data.aws_iam_policy_document.this_batch_ingest_access.json}"
+
+  environment {
+    variables {
+      JobClassName = "IngestBatchStatusEmailJobs::StalledJob"
+      QueueUrl     = "${aws_sqs_queue.this_batch_queue.id}"
+      Secret       = "${random_id.secret_key_base.hex}"
+    }
+  }
+}

--- a/applications/avr/lambdas/batch_status/index.js
+++ b/applications/avr/lambdas/batch_status/index.js
@@ -1,0 +1,31 @@
+const AWS = require('aws-sdk');
+const uuid = require('uuid/v4');
+const crypto = require('crypto-js');
+
+exports.handler = (event, context, callback) => {
+  AWS.config.region = context.invokedFunctionArn.match(/^arn:aws:lambda:(\w+-\w+-\d+):/)[1];
+
+  var message = {
+    "job_class": process.env.JobClassName,
+    "job_id": uuid(),
+    "queue_name": "batch_ingest",
+    "locale":"en"
+  }
+
+  var sqs = new AWS.SQS();
+  var body = JSON.stringify(message);
+  var digest = crypto.HmacSHA1(body,process.env.Secret).toString();
+  var params = {
+    MessageBody: body,
+    QueueUrl: process.env.QueueUrl,
+    MessageAttributes: {
+      "origin": { DataType: "String", StringValue: "AEJ" },
+      "message-digest": { DataType: "String", StringValue: digest }
+    }
+  };
+  if (process.env.QueueUrl.match(/\.fifo$/)) {
+    params.MessageDeduplicationId = message['job_id']
+    params.MessageGroupId = context.invokedFunctionArn
+  }
+  sqs.sendMessage(params, callback);
+}

--- a/applications/avr/lambdas/batch_status/package.json
+++ b/applications/avr/lambdas/batch_status/package.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "aws-sdk": "^2.229.1",
+    "crypto-js": "latest",
+    "uuid": "^3.2.1"
+  },
+  "description": "AWS Lambda function to have Avalon invoke its batch status report jobs.",
+  "directories": {},
+  "license": "Apache-2.0",
+  "main": "./index.js",
+  "maintainers": [
+    {
+      "name": "mbklein",
+      "email": "mbklein@gmail.com"
+    }
+  ],
+  "name": "avalon-batch-status",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
refs: https://github.com/nulib/avalon/issues/391

This should be the generic job we need.  The cloudwatch panel can then be set to enqueue:

`IngestBatchStatusEmailJobs::IngestFinished` every 15 minutes (or some reasonably frequent rate) and `IngestBatchStatusEmailJobs::StalledJob` every 24 hours