### PR TITLE
Puppet enterprise

### DIFF
--- a/stack/outputs.tf
+++ b/stack/outputs.tf
@@ -48,6 +48,7 @@ output "vpc_cidr_block" {
 output "security_groups" {
   value = {
     bastion    = "${aws_security_group.bastion.id}"
+    pe         = "${aws_security_group.pe.id}"
     cache      = "${aws_security_group.redis.id}"
     cantaloupe = "${module.cantaloupe_service.lb_security_group}"
     db         = "${aws_security_group.db.id}"
@@ -65,6 +66,10 @@ output "application_source_bucket" {
 
 output "bastion_address" {
   value = "${aws_route53_record.bastion.name}"
+}
+
+output "pe_address" {
+  value = "${aws_route53_record.pe.name}"
 }
 
 output "cache_address" {

--- a/stack/pe.tf
+++ b/stack/pe.tf
@@ -80,13 +80,22 @@ resource "aws_security_group" "pe" {
   tags        = "${local.common_tags}"
 }
 
+resource "aws_security_group_rule" "allow_pe_self_access" {
+  security_group_id        = "${aws_security_group.pe.id}"
+  type                     = "ingress"
+  from_port                = "0"
+  to_port                  = "0"
+  protocol                 = "-1"
+  source_security_group_id = "${aws_security_group.pe.id}"
+}
+
 resource "aws_security_group_rule" "pe_ssh_ingress" {
-  security_group_id = "${aws_security_group.pe.id}"
-  type              = "ingress"
-  from_port         = "22"
-  to_port           = "22"
-  protocol          = "tcp"
-  cidr_blocks       = ["129.105.203.0/24"]
+ security_group_id = "${aws_security_group.pe.id}"
+ type              = "ingress"
+ from_port         = "22"
+ to_port           = "22"
+ protocol          = "tcp"
+ cidr_blocks       = ["129.105.203.0/24"]
 }
 
 resource "aws_security_group_rule" "pe_https_ingress" {
@@ -96,6 +105,42 @@ resource "aws_security_group_rule" "pe_https_ingress" {
   to_port           = "443"
   protocol          = "tcp"
   cidr_blocks       = ["129.105.203.0/24"]
+}
+
+resource "aws_security_group_rule" "pe_mcollective_ingress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "ingress"
+  from_port         = "61613"
+  to_port           = "61613"
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/8"]
+}
+
+resource "aws_security_group_rule" "pe_orchestration_srv1_ingress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "ingress"
+  from_port         = "8142"
+  to_port           = "8142"
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/8"]
+}
+
+resource "aws_security_group_rule" "pe_orchestration_srv2_ingress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "ingress"
+  from_port         = "8143"
+  to_port           = "8143"
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/8"]
+}
+
+resource "aws_security_group_rule" "pe_master_ingress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "ingress"
+  from_port         = "8140"
+  to_port           = "8140"
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/8"]
 }
 
 resource "aws_security_group_rule" "pe_egress" {

--- a/stack/pe.tf
+++ b/stack/pe.tf
@@ -80,13 +80,22 @@ resource "aws_security_group" "pe" {
   tags        = "${local.common_tags}"
 }
 
-resource "aws_security_group_rule" "pe_ingress" {
+resource "aws_security_group_rule" "pe_ssh_ingress" {
   security_group_id = "${aws_security_group.pe.id}"
   type              = "ingress"
   from_port         = "22"
   to_port           = "22"
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["129.105.203.0/24"]
+}
+
+resource "aws_security_group_rule" "pe_https_ingress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "ingress"
+  from_port         = "443"
+  to_port           = "443"
+  protocol          = "tcp"
+  cidr_blocks       = ["129.105.203.0/24"]
 }
 
 resource "aws_security_group_rule" "pe_egress" {
@@ -112,7 +121,6 @@ resource "aws_instance" "pe" {
     "${aws_security_group.redis.id}",
     "${aws_security_group.elasticsearch.id}",
     "${aws_security_group.pe.id}",
-    "${aws_security_group.db.id}",
     "${aws_security_group.db_client.id}",
   ]
 
@@ -129,7 +137,7 @@ resource "null_resource" "provision_pe" {
   provisioner "file" {
     connection {
       host        = "${aws_instance.pe.public_dns}"
-      user        = "ec2-user"
+      user        = "puppetadmin"
       agent       = true
       timeout     = "3m"
       private_key = "${file(var.ec2_private_keyfile)}"
@@ -142,18 +150,18 @@ resource "null_resource" "provision_pe" {
   provisioner "remote-exec" {
     connection {
       host        = "${aws_instance.pe.public_dns}"
-      user        = "ec2-user"
+      user        = "puppetadmin"
       agent       = true
       timeout     = "3m"
       private_key = "${file(var.ec2_private_keyfile)}"
     }
 
-    inline = [
-      "sudo mv /tmp/mount_all_efs /usr/local/sbin/mount_all_efs",
-      "sudo mv /tmp/awssh /usr/local/bin/awssh",
-      "sudo chmod 0755 /usr/local/bin/awssh /usr/local/sbin/mount_all_efs",
-      "sudo yum install -y postgresql96 jq tmux",
-    ]
+#    inline = [
+#      "sudo mv /tmp/mount_all_efs /usr/local/sbin/mount_all_efs",
+#      "sudo mv /tmp/awssh /usr/local/bin/awssh",
+#      "sudo chmod 0755 /usr/local/bin/awssh /usr/local/sbin/mount_all_efs",
+#      "sudo yum install -y postgresql96 jq tmux",
+#    ]
   }
 }
 

--- a/stack/pe.tf
+++ b/stack/pe.tf
@@ -1,10 +1,5 @@
 data "aws_ami" "pe" {
-#  most_recent = true
-
-#  filter {
-#    name = "description"
-#    values = ["*BYOL*"]
-#  }
+  most_recent = true
 
   filter {
     name = "name"
@@ -16,25 +11,9 @@ data "aws_ami" "pe" {
     values = ["aws-marketplace"]
   }
 
-#  filter {
-#    name = "platform"
-#    values = ["Other Linux"]
-#  }
-
-#  filter {
-#    name   = "virtualization-type"
-#    values = ["hvm"]
-#  }
-
-#  filter {
-#    name   = "root-device-type"
-#    values = ["ebs"]
-#  }
-
   owners = ["679593333241"] # Puppet Enterprise
 
   name_regex = "BYOL"
-
 }
 
 data "aws_iam_policy_document" "pe" {
@@ -129,7 +108,11 @@ resource "aws_instance" "pe" {
   tags                        = "${merge(local.common_tags, map("Name", "${local.namespace}-pe"))}"
 
   vpc_security_group_ids = [
+    "${aws_security_group.bastion.id}",
+    "${aws_security_group.redis.id}",
+    "${aws_security_group.elasticsearch.id}",
     "${aws_security_group.pe.id}",
+    "${aws_security_group.db.id}",
     "${aws_security_group.db_client.id}",
   ]
 

--- a/stack/pe.tf
+++ b/stack/pe.tf
@@ -1,0 +1,183 @@
+data "aws_ami" "pe" {
+#  most_recent = true
+
+#  filter {
+#    name = "description"
+#    values = ["*BYOL*"]
+#  }
+
+  filter {
+    name = "name"
+    values = ["Puppet*"]
+  }
+
+  filter {
+    name = "owner-alias"
+    values = ["aws-marketplace"]
+  }
+
+#  filter {
+#    name = "platform"
+#    values = ["Other Linux"]
+#  }
+
+#  filter {
+#    name   = "virtualization-type"
+#    values = ["hvm"]
+#  }
+
+#  filter {
+#    name   = "root-device-type"
+#    values = ["ebs"]
+#  }
+
+  owners = ["679593333241"] # Puppet Enterprise
+
+  name_regex = "BYOL"
+
+}
+
+data "aws_iam_policy_document" "pe" {
+  statement {
+    sid = ""
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_instance_profile" "pe" {
+  name = "${local.namespace}-pe-profile"
+  role = "${aws_iam_role.pe.name}"
+}
+
+resource "aws_iam_role" "pe" {
+  name               = "${local.namespace}-pe-role"
+  assume_role_policy = "${data.aws_iam_policy_document.pe.json}"
+}
+
+data "aws_iam_policy_document" "pe_api_access" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ec2:DescribeInstances"]
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["elasticfilesystem:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "pe_api_access" {
+  name   = "${local.namespace}-pe-api-access"
+  policy = "${data.aws_iam_policy_document.pe_api_access.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "pe_api_access" {
+  role       = "${aws_iam_role.pe.name}"
+  policy_arn = "${aws_iam_policy.pe_api_access.arn}"
+}
+
+resource "aws_security_group" "pe" {
+  name        = "${local.namespace}-pe"
+  description = "PE Security Group"
+  vpc_id      = "${module.vpc.vpc_id}"
+  tags        = "${local.common_tags}"
+}
+
+resource "aws_security_group_rule" "pe_ingress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "pe_egress" {
+  security_group_id = "${aws_security_group.pe.id}"
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "0"
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_instance" "pe" {
+  ami                         = "${data.aws_ami.pe.id}"
+  instance_type               = "${var.pe_instance_type}"
+  key_name                    = "${var.ec2_keyname}"
+  subnet_id                   = "${module.vpc.public_subnets[0]}"
+  associate_public_ip_address = true
+  iam_instance_profile        = "${aws_iam_instance_profile.pe.name}"
+  tags                        = "${merge(local.common_tags, map("Name", "${local.namespace}-pe"))}"
+
+  vpc_security_group_ids = [
+    "${aws_security_group.pe.id}",
+    "${aws_security_group.db_client.id}",
+  ]
+
+  lifecycle {
+    ignore_changes = ["ami"]
+  }
+}
+
+resource "null_resource" "provision_pe" {
+  triggers {
+    host = "${aws_instance.pe.id}"
+  }
+
+  provisioner "file" {
+    connection {
+      host        = "${aws_instance.pe.public_dns}"
+      user        = "ec2-user"
+      agent       = true
+      timeout     = "3m"
+      private_key = "${file(var.ec2_private_keyfile)}"
+    }
+
+    source      = "${path.module}/files/"
+    destination = "/tmp/"
+  }
+
+  provisioner "remote-exec" {
+    connection {
+      host        = "${aws_instance.pe.public_dns}"
+      user        = "ec2-user"
+      agent       = true
+      timeout     = "3m"
+      private_key = "${file(var.ec2_private_keyfile)}"
+    }
+
+    inline = [
+      "sudo mv /tmp/mount_all_efs /usr/local/sbin/mount_all_efs",
+      "sudo mv /tmp/awssh /usr/local/bin/awssh",
+      "sudo chmod 0755 /usr/local/bin/awssh /usr/local/sbin/mount_all_efs",
+      "sudo yum install -y postgresql96 jq tmux",
+    ]
+  }
+}
+
+resource "aws_route53_record" "pe" {
+  zone_id = "${module.dns.public_zone_id}"
+  name    = "pe.${local.public_zone_name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${aws_instance.pe.public_ip}"]
+}

--- a/stack/variables.tf
+++ b/stack/variables.tf
@@ -13,6 +13,11 @@ variable "bastion_instance_type" {
   default = "t2.small"
 }
 
+variable "pe_instance_type" {
+  type    = "string"
+  default = "t2.xlarge"
+}
+
 variable "db_master_username" {
   type    = "string"
   default = "dbadmin"

--- a/stack/variables.tf
+++ b/stack/variables.tf
@@ -15,7 +15,7 @@ variable "bastion_instance_type" {
 
 variable "pe_instance_type" {
   type    = "string"
-  default = "t2.xlarge"
+  default = "m4.xlarge"
 }
 
 variable "db_master_username" {


### PR DESCRIPTION
This code deploys a PE server from a PuppetLabs-supported AMI including firewall rules to allow ssh and https to the pe server only from the NUL Admin network, et al.  There are additional configuration steps to make the pe server actually do stuff, which I have documented and will push up into a new aws-pe repository wiki.