### PR TITLE
Deactivated 365d lifecycle rule for stack-{x}-donut-batch, until after Images migration

### DIFF
--- a/applications/donut/main.tf
+++ b/applications/donut/main.tf
@@ -181,7 +181,7 @@ resource "aws_s3_bucket" "this_batch" {
 
   lifecycle_rule {
     id                                     = "batch-delete-after-365-days"
-    enabled                                = true
+    enabled                                = false
     abort_incomplete_multipart_upload_days = 3
 
     expiration {


### PR DESCRIPTION
Simple change, setting lifecycle rule to "disabled" for stack-x-donut batch.  (Was 365-day lifecycle)

.